### PR TITLE
[SECURITY] Path sanitization hardening for plugin traversal protection

### DIFF
--- a/internal/claude/plugin.go
+++ b/internal/claude/plugin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/jdforsythe/jig/internal/config"
 	"github.com/jdforsythe/jig/internal/plugin"
@@ -95,7 +96,10 @@ func GeneratePluginDir(p *config.Profile, mcpIndex *MCPIndex) (pluginDir, settin
 		}
 		for _, s := range p.Skills {
 			src := expandPath(s.Path)
-			name := filepath.Base(src)
+			name, nameErr := safeBaseName(src)
+			if nameErr != nil {
+				return "", "", fmt.Errorf("invalid skill path %q: %w", s.Path, nameErr)
+			}
 			if err = os.Symlink(src, filepath.Join(skillsDir, name)); err != nil {
 				return "", "", fmt.Errorf("symlinking skill %s: %w", s.Path, err)
 			}
@@ -110,7 +114,10 @@ func GeneratePluginDir(p *config.Profile, mcpIndex *MCPIndex) (pluginDir, settin
 		}
 		for _, a := range p.Agents {
 			src := expandPath(a.Path)
-			name := filepath.Base(src)
+			name, nameErr := safeBaseName(src)
+			if nameErr != nil {
+				return "", "", fmt.Errorf("invalid agent path %q: %w", a.Path, nameErr)
+			}
 			if err = os.Symlink(src, filepath.Join(agentsDir, name)); err != nil {
 				return "", "", fmt.Errorf("symlinking agent %s: %w", a.Path, err)
 			}
@@ -125,7 +132,10 @@ func GeneratePluginDir(p *config.Profile, mcpIndex *MCPIndex) (pluginDir, settin
 		}
 		for _, c := range p.Commands {
 			src := expandPath(c.Path)
-			name := filepath.Base(src)
+			name, nameErr := safeBaseName(src)
+			if nameErr != nil {
+				return "", "", fmt.Errorf("invalid command path %q: %w", c.Path, nameErr)
+			}
 			if err = os.Symlink(src, filepath.Join(commandsDir, name)); err != nil {
 				return "", "", fmt.Errorf("symlinking command %s: %w", c.Path, err)
 			}
@@ -146,11 +156,15 @@ func GeneratePluginDir(p *config.Profile, mcpIndex *MCPIndex) (pluginDir, settin
 					return "", "", err
 				}
 				for _, name := range sel.Agents {
-					src := filepath.Join(installPath, "agents", name)
-					dest := filepath.Join(agentsDir, name)
+					safeName, nameErr := safeComponentName(name)
+					if nameErr != nil {
+						return "", "", fmt.Errorf("invalid plugin agent name %q for %q: %w", name, pluginKey, nameErr)
+					}
+					src := filepath.Join(installPath, "agents", safeName)
+					dest := filepath.Join(agentsDir, safeName)
 					if _, statErr := os.Lstat(dest); os.IsNotExist(statErr) {
 						if err = os.Symlink(src, dest); err != nil {
-							return "", "", fmt.Errorf("symlinking plugin agent %s/%s: %w", pluginKey, name, err)
+							return "", "", fmt.Errorf("symlinking plugin agent %s/%s: %w", pluginKey, safeName, err)
 						}
 					}
 				}
@@ -162,11 +176,15 @@ func GeneratePluginDir(p *config.Profile, mcpIndex *MCPIndex) (pluginDir, settin
 					return "", "", err
 				}
 				for _, name := range sel.Skills {
-					src := filepath.Join(installPath, "skills", name)
-					dest := filepath.Join(skillsDir, name)
+					safeName, nameErr := safeComponentName(name)
+					if nameErr != nil {
+						return "", "", fmt.Errorf("invalid plugin skill name %q for %q: %w", name, pluginKey, nameErr)
+					}
+					src := filepath.Join(installPath, "skills", safeName)
+					dest := filepath.Join(skillsDir, safeName)
 					if _, statErr := os.Lstat(dest); os.IsNotExist(statErr) {
 						if err = os.Symlink(src, dest); err != nil {
-							return "", "", fmt.Errorf("symlinking plugin skill %s/%s: %w", pluginKey, name, err)
+							return "", "", fmt.Errorf("symlinking plugin skill %s/%s: %w", pluginKey, safeName, err)
 						}
 					}
 				}
@@ -178,11 +196,15 @@ func GeneratePluginDir(p *config.Profile, mcpIndex *MCPIndex) (pluginDir, settin
 					return "", "", err
 				}
 				for _, name := range sel.Commands {
-					src := filepath.Join(installPath, "commands", name)
-					dest := filepath.Join(commandsDir, name)
+					safeName, nameErr := safeComponentName(name)
+					if nameErr != nil {
+						return "", "", fmt.Errorf("invalid plugin command name %q for %q: %w", name, pluginKey, nameErr)
+					}
+					src := filepath.Join(installPath, "commands", safeName)
+					dest := filepath.Join(commandsDir, safeName)
 					if _, statErr := os.Lstat(dest); os.IsNotExist(statErr) {
 						if err = os.Symlink(src, dest); err != nil {
-							return "", "", fmt.Errorf("symlinking plugin command %s/%s: %w", pluginKey, name, err)
+							return "", "", fmt.Errorf("symlinking plugin command %s/%s: %w", pluginKey, safeName, err)
 						}
 					}
 				}
@@ -228,7 +250,10 @@ func GeneratePluginDir(p *config.Profile, mcpIndex *MCPIndex) (pluginDir, settin
 	// Copy hook scripts
 	for _, hs := range p.HookScripts {
 		src := expandPath(hs.Path)
-		dest := filepath.Join(tmpDir, hs.Dest)
+		dest, joinErr := safeJoinWithin(tmpDir, hs.Dest)
+		if joinErr != nil {
+			return "", "", fmt.Errorf("invalid hook script destination %q: %w", hs.Dest, joinErr)
+		}
 		if err = os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 			return "", "", err
 		}
@@ -284,4 +309,51 @@ func expandPath(path string) string {
 		}
 	}
 	return path
+}
+
+func safeBaseName(path string) (string, error) {
+	name := filepath.Base(path)
+	return safeComponentName(name)
+}
+
+func safeComponentName(name string) (string, error) {
+	if name == "" || name == "." || name == ".." {
+		return "", fmt.Errorf("name must not be empty, '.' or '..'")
+	}
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	if filepath.Base(name) != name {
+		return "", fmt.Errorf("path separators are not allowed")
+	}
+	if strings.Contains(name, "\\") || strings.Contains(name, "/") {
+		return "", fmt.Errorf("path separators are not allowed")
+	}
+	return name, nil
+}
+
+func safeJoinWithin(baseDir, rel string) (string, error) {
+	if rel == "" {
+		return "", fmt.Errorf("destination must not be empty")
+	}
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("absolute destination paths are not allowed")
+	}
+
+	cleanRel := filepath.Clean(rel)
+	if cleanRel == "." || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("destination escapes plugin directory")
+	}
+
+	baseClean := filepath.Clean(baseDir)
+	dest := filepath.Join(baseClean, cleanRel)
+	relToBase, err := filepath.Rel(baseClean, dest)
+	if err != nil {
+		return "", err
+	}
+	if relToBase == ".." || strings.HasPrefix(relToBase, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("destination escapes plugin directory")
+	}
+
+	return dest, nil
 }

--- a/internal/claude/plugin_extra_test.go
+++ b/internal/claude/plugin_extra_test.go
@@ -356,3 +356,144 @@ func TestExpandPath_TildeOnly(t *testing.T) {
 		t.Errorf("expandPath(~) = %q, want ~ (no expansion without trailing /)", result)
 	}
 }
+
+// TestSafeComponentName tests the safeComponentName safety function
+func TestSafeComponentName_AcceptsLegitimate(t *testing.T) {
+	tests := []string{
+		"my-agent",
+		"skill_v2",
+		"CommandWithNumbers123",
+		"a",
+		"name-with-many-dashes",
+	}
+	for _, name := range tests {
+		_, err := safeComponentName(name)
+		if err != nil {
+			t.Errorf("safeComponentName(%q) should accept, got error: %v", name, err)
+		}
+	}
+}
+
+func TestSafeComponentName_RejectsEmpty(t *testing.T) {
+	_, err := safeComponentName("")
+	if err == nil {
+		t.Error("safeComponentName(\"\") should reject empty string, got no error")
+	}
+}
+
+func TestSafeComponentName_RejectsDot(t *testing.T) {
+	_, err := safeComponentName(".")
+	if err == nil {
+		t.Error("safeComponentName(\".\") should reject dot, got no error")
+	}
+}
+
+func TestSafeComponentName_RejectsDotDot(t *testing.T) {
+	_, err := safeComponentName("..")
+	if err == nil {
+		t.Error("safeComponentName(\"..\") should reject dotdot, got no error")
+	}
+}
+
+func TestSafeComponentName_RejectsAbsolutePath(t *testing.T) {
+	tests := []string{
+		"/etc/passwd",
+		"/absolute/path",
+	}
+	for _, name := range tests {
+		_, err := safeComponentName(name)
+		if err == nil {
+			t.Errorf("safeComponentName(%q) should reject absolute path, got no error", name)
+		}
+	}
+}
+
+func TestSafeComponentName_RejectsPathSeparators(t *testing.T) {
+	tests := []string{
+		"../../../etc/passwd",
+		"subdir/agent",
+		"agent/../../../etc/item",
+		"./relative/path",
+	}
+	for _, name := range tests {
+		_, err := safeComponentName(name)
+		if err == nil {
+			t.Errorf("safeComponentName(%q) should reject path separators, got no error", name)
+		}
+	}
+}
+
+// TestSafeJoinWithin tests the safeJoinWithin safety function
+func TestSafeJoinWithin_AcceptsLegitimate(t *testing.T) {
+	baseDir := t.TempDir()
+	tests := []string{
+		"hooks/script.sh",
+		"validate.sh",
+		"subdir/nested/hooks.json",
+		"file.txt",
+	}
+	for _, relPath := range tests {
+		_, err := safeJoinWithin(baseDir, relPath)
+		if err != nil {
+			t.Errorf("safeJoinWithin(baseDir, %q) should accept, got error: %v", relPath, err)
+		}
+	}
+}
+
+func TestSafeJoinWithin_RejectsAbolutePath(t *testing.T) {
+	baseDir := t.TempDir()
+	tests := []string{
+		"/etc/passwd",
+		"/absolute/path/to/file",
+	}
+	for _, relPath := range tests {
+		_, err := safeJoinWithin(baseDir, relPath)
+		if err == nil {
+			t.Errorf("safeJoinWithin(baseDir, %q) should reject absolute path, got no error", relPath)
+		}
+	}
+}
+
+func TestSafeJoinWithin_RejectsDirectoryTraversal(t *testing.T) {
+	baseDir := t.TempDir()
+	tests := []string{
+		"..",
+		"../../../etc/passwd",
+		"subdir/../../outside",
+	}
+	for _, relPath := range tests {
+		_, err := safeJoinWithin(baseDir, relPath)
+		if err == nil {
+			t.Errorf("safeJoinWithin(baseDir, %q) should reject directory traversal, got no error", relPath)
+		}
+	}
+}
+
+func TestSafeJoinWithin_ComputesCorrectPath(t *testing.T) {
+	baseDir := t.TempDir()
+	relPath := "hooks/validate.sh"
+
+	result, err := safeJoinWithin(baseDir, relPath)
+	if err != nil {
+		t.Fatalf("safeJoinWithin failed: %v", err)
+	}
+
+	expected := filepath.Join(baseDir, relPath)
+	if result != expected {
+		t.Errorf("safeJoinWithin result = %q, want %q", result, expected)
+	}
+}
+
+func TestSafeBaseName_AcceptsLegitimate(t *testing.T) {
+	tests := []string{
+		"my-skill",
+		"agent_v2",
+		"Command",
+	}
+	for _, path := range tests {
+		_, err := safeBaseName(path)
+		if err != nil {
+			t.Errorf("safeBaseName(%q) should accept, got error: %v", path, err)
+		}
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+	"strings"
 )
 
 func TestValidate(t *testing.T) {
@@ -251,5 +252,142 @@ func TestPaths(t *testing.T) {
 	profilePath := ProfilePath("/some/dir", "my-profile")
 	if profilePath != "/some/dir/my-profile.yaml" {
 		t.Errorf("ProfilePath: got %q", profilePath)
+	}
+}
+
+// TestValidateComponentName_AcceptsLegitimate tests the validateComponentName helper
+func TestValidateComponentName_AcceptsLegitimate(t *testing.T) {
+	tests := []string{
+		"my-agent",
+		"skill-v2",
+		"component-a",
+		"name-with-dashes",
+	}
+	for _, name := range tests {
+		err := validateComponentName(name)
+		if err != nil {
+			t.Errorf("validateComponentName(%q) should accept, got error: %v", name, err)
+		}
+	}
+}
+
+func TestValidateComponentName_RejectsEmpty(t *testing.T) {
+	err := validateComponentName("")
+	if err == nil {
+		t.Error("validateComponentName(\"\") should reject empty string")
+	}
+}
+
+func TestValidateComponentName_RejectsDot(t *testing.T) {
+	err := validateComponentName(".")
+	if err == nil {
+		t.Error("validateComponentName(\".\") should reject dot")
+	}
+}
+
+func TestValidateComponentName_RejectsDotDot(t *testing.T) {
+	err := validateComponentName("..")
+	if err == nil {
+		t.Error("validateComponentName(\"..\") should reject dotdot")
+	}
+}
+
+func TestValidateComponentName_RejectsAbsolutePath(t *testing.T) {
+	tests := []string{
+		"/etc/passwd",
+		"/absolute/path",
+	}
+	for _, name := range tests {
+		err := validateComponentName(name)
+		if err == nil {
+			t.Errorf("validateComponentName(%q) should reject absolute path", name)
+		}
+	}
+}
+
+func TestValidateComponentName_RejectsPathSeparators(t *testing.T) {
+	tests := []string{
+		"../../../etc/passwd",
+		"subdir/agent",
+		"agent/../../../etc/item",
+		"./relative/path",
+	}
+	for _, name := range tests {
+		err := validateComponentName(name)
+		if err == nil {
+			t.Errorf("validateComponentName(%q) should reject path separators", name)
+		}
+	}
+}
+
+func TestValidate_RejectsAbsoluteHookScriptDest(t *testing.T) {
+	p := &Profile{
+		Name: "test",
+		HookScripts: []HookScript{
+			{Dest: "/etc/passwd", Path: "somescript.sh"},
+		},
+	}
+	err := Validate(p)
+	if err == nil {
+		t.Error("Validate should reject absolute hook_scripts destination")
+	}
+}
+
+func TestValidate_RejectsTraversalHookScriptDest(t *testing.T) {
+	p := &Profile{
+		Name: "test",
+		HookScripts: []HookScript{
+			{Dest: "../../outside/directory/file", Path: "somescript.sh"},
+		},
+	}
+	err := Validate(p)
+	if err == nil {
+		t.Error("Validate should reject traversal in hook_scripts destination")
+	}
+}
+
+func TestValidate_AcceptsLegitimateHookScriptDest(t *testing.T) {
+	p := &Profile{
+		Name: "test",
+		HookScripts: []HookScript{
+			{Dest: "hooks/validate.sh", Path: "scripts/validate.sh"},
+			{Dest: "script.sh", Path: "scripts/other.sh"},
+		},
+	}
+	err := Validate(p)
+	if err != nil && strings.Contains(err.Error(), "hook_scripts") {
+		t.Errorf("Validate should accept legitimate hook_scripts destination: %v", err)
+	}
+}
+
+func TestValidate_RejectsInvalidPluginComponentName(t *testing.T) {
+	p := &Profile{
+		Name: "test",
+		PluginComponents: map[string]PluginComponentSelection{
+			"plugin1": {
+				Agents: []string{"../../../etc/passwd"},
+			},
+		},
+	}
+	err := Validate(p)
+	if err == nil {
+		t.Error("Validate should reject invalid plugin component name in agents")
+	}
+}
+
+func TestValidate_AcceptsValidPluginComponentName(t *testing.T) {
+	p := &Profile{
+		Name: "test",
+		PluginComponents: map[string]PluginComponentSelection{
+			"plugin1": {
+				Agents:   []string{"reviewer-agent"},
+				Skills:   []string{"code-analyzer"},
+				Commands: []string{"validate"},
+			},
+		},
+	}
+	err := Validate(p)
+	if err != nil && strings.Contains(err.Error(), "plugin_components") {
+		t.Errorf("Validate should accept valid plugin component names: %v", err)
 	}
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -64,6 +65,35 @@ func Validate(p *Profile) error {
 		}
 		if hs.Dest == "" {
 			errs = append(errs, fmt.Sprintf("hook_scripts[%d]: dest is required", i))
+			continue
+		}
+		if filepath.IsAbs(hs.Dest) {
+			errs = append(errs, fmt.Sprintf("hook_scripts[%d]: dest must be a relative path", i))
+		}
+		cleanDest := filepath.Clean(hs.Dest)
+		if cleanDest == "." || cleanDest == ".." || strings.HasPrefix(cleanDest, ".."+string(filepath.Separator)) {
+			errs = append(errs, fmt.Sprintf("hook_scripts[%d]: dest must stay within plugin directory", i))
+		}
+	}
+
+	for pluginKey, sel := range p.PluginComponents {
+		if pluginKey == "" {
+			errs = append(errs, "plugin_components: plugin key must not be empty")
+		}
+		for i, name := range sel.Agents {
+			if err := validateComponentName(name); err != nil {
+				errs = append(errs, fmt.Sprintf("plugin_components[%q].agents[%d]: %v", pluginKey, i, err))
+			}
+		}
+		for i, name := range sel.Skills {
+			if err := validateComponentName(name); err != nil {
+				errs = append(errs, fmt.Sprintf("plugin_components[%q].skills[%d]: %v", pluginKey, i, err))
+			}
+		}
+		for i, name := range sel.Commands {
+			if err := validateComponentName(name); err != nil {
+				errs = append(errs, fmt.Sprintf("plugin_components[%q].commands[%d]: %v", pluginKey, i, err))
+			}
 		}
 	}
 
@@ -89,4 +119,20 @@ func contains(slice []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func validateComponentName(name string) error {
+	if name == "" || name == "." || name == ".." {
+		return fmt.Errorf("name must not be empty, '.' or '..'")
+	}
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("absolute paths are not allowed")
+	}
+	if filepath.Base(name) != name {
+		return fmt.Errorf("path separators are not allowed")
+	}
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return fmt.Errorf("path separators are not allowed")
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

This PR addresses three security vulnerabilities related to path traversal and arbitrary file write attacks in jig's plugin and hook script handling.

## Vulnerabilities Fixed

### 1. Arbitrary file write via unvalidated `hook_scripts.dest`
**File:** `internal/claude/plugin.go`
**Severity:** High  
**Attack vector:** A malicious project `.jig.yaml` or profile sets `hook_scripts[*].dest` to a path like `../../../etc/cron.d/backdoor`. Since `filepath.Join` was called without containment checks, this would write the hook script to an arbitrary location on disk with the user's privileges.

**Fix:** Introduced `safeJoinWithin(baseDir, rel string)` which uses `filepath.Clean` + `filepath.Rel` to verify the resolved destination is strictly within the plugin temp directory before performing the join.

### 2. Arbitrary symlink creation via unsanitized plugin component names
**File:** `internal/claude/plugin.go`  
**Severity:** High  
**Attack vector:** A malicious plugin definition exposes components with names like `../../../home/user/.ssh/authorized_keys`. These names were used directly in `filepath.Join` for symlink destinations, allowing symlinks to be created at arbitrary paths.

**Fix:** Introduced `safeComponentName(name string)` which rejects empty strings, `.`, `..`, absolute paths, and any name containing path separators. `safeBaseName` wraps this for symlink source path handling.

### 3. Validation gap at profile load time
**File:** `internal/config/validate.go`  
**Severity:** Medium  
**Attack vector:** Malicious path values could pass `Validate()` and only fail (or not fail) at runtime during plugin directory generation, with no user-visible error.

**Fix:** Added `validateComponentName` helper to validation layer; `Validate()` now enforces absolute-path and traversal rejection for `hook_scripts[*].dest` and all `plugin_components[*].agents/skills/commands` entries at profile load time.

## Changes

| File | Change |
|------|--------|
| `internal/claude/plugin.go` | Added `safeComponentName`, `safeBaseName`, `safeJoinWithin` helpers; integrated into 6 symlink loops + 1 hook script copy |
| `internal/config/validate.go` | Added `validateComponentName` helper; added validation checks for hook script dest and plugin component names |
| `internal/claude/plugin_extra_test.go` | Added 11 tests for new safety functions |
| `internal/config/config_test.go` | Added 11 tests for validation-layer safety checks |

## Testing

All existing and new tests pass:

```
ok  github.com/jdforsythe/jig/internal/claude   0.034s
ok  github.com/jdforsythe/jig/internal/config   0.037s
ok  github.com/jdforsythe/jig/internal/plugin   0.033s
ok  github.com/jdforsythe/jig/internal/scanner  0.021s
ok  github.com/jdforsythe/jig/internal/tui/screens 0.008s
```

## Usability Impact

**None.** Legitimate paths pass all checks:
- Component names like `my-agent`, `code-analyzer`, `validate` ✓
- Hook destinations like `hooks/script.sh`, `validate.sh` ✓
- Only traversal and absolute path attacks are rejected ✗

## Deferred (Behavior-Changing)

Two additional hardening opportunities were identified but not implemented as they would change existing behavior and require user discussion:

1. **Project config trust gate** — `system_prompt` and `extra_flags` from project-local profiles are currently applied without approval. An interactive prompt on first use of a project profile could be added.
2. **MCP server override approval** — Project `.mcp.json` definitions currently override global `~/.claude/.mcp.json` without confirmation. A read-only append policy (project can add new servers but not override existing globals) could be considered.